### PR TITLE
Allow classmethods to return sub-classes

### DIFF
--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -6,6 +6,7 @@ from typing import (
     Generic,
     Literal,
     Mapping,
+    Self,
     TypeVar,
     Union,
     cast,
@@ -119,9 +120,6 @@ class NodeSpec(StrictBase):
     zarr_version: Literal[2] = 2
 
 
-ArraySpecType = TypeVar("ArraySpecType", bound="ArraySpec")
-
-
 class ArraySpec(NodeSpec, Generic[TAttr]):
     """
     A model of a Zarr Version 2 Array. The specification for the data structure being modeled by
@@ -182,7 +180,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
 
     @classmethod
     def from_array(
-        cls: type[ArraySpecType],
+        cls,
         array: npt.NDArray[Any],
         chunks: Literal["auto"] | tuple[int, ...] = "auto",
         attributes: Literal["auto"] | TAttr = "auto",
@@ -191,7 +189,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         filters: Literal["auto"] | list[CodecDict] | None = "auto",
         dimension_separator: Literal["auto", "/", "."] = "auto",
         compressor: Literal["auto"] | CodecDict | None = "auto",
-    ) -> ArraySpecType:
+    ) -> Self:
         """
         Create an `ArraySpec` from an array-like object. This is a convenience method for when Zarr array will be modelled from an existing array.
         This method takes nearly the same arguments as the `ArraySpec` constructor, minus `shape` and `dtype`, which will be inferred from the `array` argument.
@@ -289,7 +287,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         )
 
     @classmethod
-    def from_zarr(cls: type[ArraySpecType], array: zarr.Array) -> ArraySpecType:
+    def from_zarr(cls, array: zarr.Array) -> Self:
         """
         Create an `ArraySpec` from an instance of `zarr.Array`.
 
@@ -445,9 +443,6 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         return result
 
 
-GroupSpecType = TypeVar("GroupSpecType", bound="GroupSpec")
-
-
 class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
     """
     A model of a Zarr Version 2 Group.
@@ -471,9 +466,7 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
     members: Annotated[dict[str, TItem] | None, AfterValidator(ensure_key_no_path)] = {}
 
     @classmethod
-    def from_zarr(
-        cls: type[GroupSpecType], group: zarr.Group, *, depth: int = -1
-    ) -> GroupSpecType:
+    def from_zarr(cls, group: zarr.Group, *, depth: int = -1) -> Self:
         """
         Create a GroupSpec from an instance of `zarr.Group`. Subgroups and arrays contained in the
         Zarr group will be converted to instances of `GroupSpec` and `ArraySpec`, respectively,
@@ -689,9 +682,7 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
         return to_flat(self, root_path=root_path)
 
     @classmethod
-    def from_flat(
-        cls: type[GroupSpecType], data: Dict[str, ArraySpec | GroupSpec]
-    ) -> GroupSpecType:
+    def from_flat(cls, data: Dict[str, ArraySpec | GroupSpec]) -> Self:
         """
         Create a `GroupSpec` from a flat hierarchy representation. The flattened hierarchy is a
         `dict` with the following constraints: keys must be valid paths; values must

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -276,7 +276,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
 
         return cls(
             shape=shape_actual,
-            dtype=dtype_actual.str,
+            dtype=stringify_dtype(dtype_actual),
             chunks=chunks_actual,
             attributes=attributes_actual,
             fill_value=fill_value_actual,


### PR DESCRIPTION
Currently the `from_zarr()` methods are not typed as returning sub-classes correctly. As a concrete example, this means that in this line:

https://github.com/BioImageTools/ome-zarr-models-py/blob/4a6851ed1487a90274058dc92ebc3a16539557ed/tests/v04/test_hcs.py#L12

the `hcs` variable does not have the type `HCS`, but instead a wider `GroupSpec` type.

This PR should fix that so the from_zarr() methods are correctly typed for sub-classes.