### PR TITLE
type hints for tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,13 @@ ci:
 default_stages: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.7
     hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
     - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args: ["-L", "fo,ihs,kake,te", "-S", "fixture"]
@@ -22,7 +22,7 @@ repos:
     - id: check-yaml
     - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         files: src|tests
@@ -30,7 +30,7 @@ repos:
           - pytest
           - pydantic
   - repo: https://github.com/scientific-python/cookie
-    rev: 2024.08.19
+    rev: 2025.01.22
     hooks:
       - id: sp-repo-review
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,3 +206,19 @@ ignore = [
     "RTD102", # read the docs, no thanks,
     "RTD103", # read the docs, no thanks
 ]
+
+[tool.numpydoc_validation]
+# See https://numpydoc.readthedocs.io/en/latest/validation.html#built-in-validation-checks for list of checks
+checks = [
+    "GL06",
+    "GL07",
+    # Currently broken; see https://github.com/numpy/numpydoc/issues/573
+    # "GL09",
+    "GL10",
+    "SS02",
+    "SS04",
+    "PR02",
+    "PR03",
+    "PR05",
+    "PR06",
+]

--- a/tests/test_pydantic_zarr/test_v3.py
+++ b/tests/test_pydantic_zarr/test_v3.py
@@ -1,7 +1,7 @@
 from pydantic_zarr.v3 import ArraySpec, GroupSpec, NamedConfig
 
 
-def test_serialize_deserialize():
+def test_serialize_deserialize() -> None:
     array_attributes = {"foo": 42, "bar": "apples", "baz": [1, 2, 3, 4]}
 
     group_attributes = {"group": True}


### PR DESCRIPTION
some housecleaning: fixes up type annotations in the tests, updates pre-commit, adds explicit numpydoc rules