### PR TITLE
Migrate to zarr-python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 
 [Pydantic](https://docs.pydantic.dev/latest/) models for [Zarr](https://zarr.readthedocs.io/en/stable/index.html).
 
-## ⚠️ Disclaimer ⚠️
-This project is under flux -- I want to add [zarr version 3](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) support to this project, but the [reference python implementation](https://github.com/zarr-developers/zarr-python) doesn't support version 3 yet. As the ecosystem evolves things will break so be advised!
-
 ## Installation
 
 `pip install -U pydantic-zarr`
@@ -56,5 +53,7 @@ print(spec.model_dump())
 }
 """
 ```
+
 ## History
+
 This project was developed at [HHMI / Janelia Research Campus](https://www.janelia.org/). It was originally written by Davis Bennett to solve problems he encountered while working on the [Cellmap Project team](https://www.janelia.org/project-team/cellmap/members). In December of 2024 this project was migrated from the [`janelia-cellmap`](https://github.com/janelia-cellmap) github organization to [`zarr-developers`](https://github.com/zarr-developers) organization.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ print(spec.model_dump())
             'dtype': '|u1',
             'fill_value': 0,
             'order': 'C',
-            'filters': [],
+            'filters': None,
             'dimension_separator': '.',
             'compressor': {'id': 'zstd', 'level': 0, 'checksum': False},
         }

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,15 +8,14 @@ Static typing and runtime validation for Zarr hierarchies.
 
 `pydantic-zarr` expresses data stored in the [Zarr](https://zarr.readthedocs.io/en/stable/) format with [Pydantic](https://docs.pydantic.dev/1.10/). Specifically, `pydantic-zarr` encodes Zarr groups and arrays as [Pydantic models](https://docs.pydantic.dev/1.10/usage/models/). These models are useful for formalizing the structure of Zarr hierarchies, type-checking Zarr hierarchies, and runtime validation for Zarr-based data.
 
-
 ```python
 import zarr
 from pydantic_zarr.v2 import GroupSpec
 
 # create a Zarr group
-group = zarr.group(path='foo')
+group = zarr.group(path='foo', zarr_format=2)
 # put an array inside the group
-array = zarr.create(store = group.store, path='foo/bar', shape=10, dtype='uint8')
+array = zarr.create(store = group.store, path='foo/bar', shape=10, dtype='uint8', zarr_format=2)
 array.attrs.put({'metadata': 'hello'})
 
 # create a pydantic model to model the Zarr group
@@ -56,11 +55,11 @@ More examples can be found in the [usage guide](usage_zarr_v2.md).
 
 `pip install -U pydantic-zarr`
 
-
 ### Limitations
 
 #### No array data operations
-This library only provides tools to represent the *layout* of Zarr groups and arrays, and the structure of their attributes. `pydantic-zarr` performs no type checking or runtime validation of the multidimensional array data contained *inside* Zarr arrays, and `pydantic-zarr` does not contain any tools for efficiently reading or writing Zarr arrays.
+
+This library only provides tools to represent the _layout_ of Zarr groups and arrays, and the structure of their attributes. `pydantic-zarr` performs no type checking or runtime validation of the multidimensional array data contained _inside_ Zarr arrays, and `pydantic-zarr` does not contain any tools for efficiently reading or writing Zarr arrays.
 
 #### Supported Zarr versions
 
@@ -84,7 +83,7 @@ In `pydantic-zarr`, Zarr groups are modeled by the `GroupSpec` class, which is a
 
 Zarr arrays are represented by the `ArraySpec` class, which has a similar `attributes` field, as well as fields for all the Zarr array properties (`dtype`, `shape`, `chunks`, etc).
 
-`GroupSpec` and `ArraySpec` are both [generic models](https://docs.pydantic.dev/1.10/usage/models/#generic-models). `GroupSpec` takes two type parameters, the first specializing the type of `GroupSpec.attributes`, and the second specializing the type of the *values* of `GroupSpec.members` (the keys of `GroupSpec.members` are always strings). `ArraySpec` only takes one type parameter, which specializes the type of `ArraySpec.attributes`.
+`GroupSpec` and `ArraySpec` are both [generic models](https://docs.pydantic.dev/1.10/usage/models/#generic-models). `GroupSpec` takes two type parameters, the first specializing the type of `GroupSpec.attributes`, and the second specializing the type of the _values_ of `GroupSpec.members` (the keys of `GroupSpec.members` are always strings). `ArraySpec` only takes one type parameter, which specializes the type of `ArraySpec.attributes`.
 
 Examples using this generic typing functionality can be found in the [usage guide](usage_zarr_v2.md#using-generic-types).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,12 +10,15 @@ Static typing and runtime validation for Zarr hierarchies.
 
 ```python
 import zarr
+
 from pydantic_zarr.v2 import GroupSpec
 
 # create a Zarr group
 group = zarr.group(path='foo', zarr_format=2)
 # put an array inside the group
-array = zarr.create(store = group.store, path='foo/bar', shape=10, dtype='uint8', zarr_format=2)
+array = zarr.create(
+    store=group.store, path='foo/bar', shape=10, dtype='uint8', zarr_format=2
+)
 array.attrs.put({'metadata': 'hello'})
 
 # create a pydantic model to model the Zarr group
@@ -34,15 +37,9 @@ print(spec.model_dump())
             'dtype': '|u1',
             'fill_value': 0,
             'order': 'C',
-            'filters': None,
+            'filters': [],
             'dimension_separator': '.',
-            'compressor': {
-                'id': 'blosc',
-                'cname': 'lz4',
-                'clevel': 5,
-                'shuffle': 1,
-                'blocksize': 0,
-            },
+            'compressor': {'id': 'zstd', 'level': 0, 'checksum': False},
         }
     },
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,10 @@ import zarr
 from pydantic_zarr.v2 import GroupSpec
 
 # create a Zarr group
-group = zarr.group(path='foo', zarr_format=2)
+group = zarr.create_group(store={}, path='foo', zarr_format=2)
 # put an array inside the group
-array = zarr.create(
-    store=group.store, path='foo/bar', shape=10, dtype='uint8', zarr_format=2
+array = zarr.create_array(
+    store=group.store, name='foo/bar', shape=10, dtype='uint8', zarr_format=2
 )
 array.attrs.put({'metadata': 'hello'})
 
@@ -35,7 +35,7 @@ print(spec.model_dump())
             'shape': (10,),
             'chunks': (10,),
             'dtype': '|u1',
-            'fill_value': 0,
+            'fill_value': None,
             'order': 'C',
             'filters': None,
             'dimension_separator': '.',

--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -17,15 +17,15 @@ To write a hierarchy to some zarr-compatible storage backend, `GroupSpec` and `A
 Note that `to_zarr` will _not_ write any array data. You have to do this separately.
 
 ```python
-from zarr import create, group
+from zarr import create_array, create_group
 
 from pydantic_zarr.v2 import GroupSpec
 
 # create an in-memory Zarr group + array with attributes
-grp = group(path='foo', zarr_format=2)
+grp = create_group(store={}, path='foo', zarr_format=2)
 grp.attrs.put({'group_metadata': 10})
-arr = create(
-    path='foo/bar', store=grp.store, shape=(10,), compressor=None, zarr_format=2
+arr = create_array(
+    name='foo/bar', store=grp.store, shape=(10,), dtype="f8", compressors=None, zarr_format=2
 )
 arr.attrs.put({'array_metadata': True})
 
@@ -42,7 +42,7 @@ print(spec.model_dump())
             'shape': (10,),
             'chunks': (10,),
             'dtype': '<f8',
-            'fill_value': 0.0,
+            'fill_value': None,
             'order': 'C',
             'filters': None,
             'dimension_separator': '.',

--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -44,7 +44,7 @@ print(spec.model_dump())
             'dtype': '<f8',
             'fill_value': 0.0,
             'order': 'C',
-            'filters': [],
+            'filters': None,
             'dimension_separator': '.',
             'compressor': None,
         }
@@ -90,7 +90,7 @@ print(ArraySpec.from_array(np.arange(10)).model_dump())
     'dtype': '<i8',
     'fill_value': 0,
     'order': 'C',
-    'filters': [],
+    'filters': None,
     'dimension_separator': '/',
     'compressor': None,
 }
@@ -143,7 +143,7 @@ print(GroupSpec.from_flat(tree).model_dump())
                     'dtype': '|u1',
                     'fill_value': 0,
                     'order': 'C',
-                    'filters': [],
+                    'filters': None,
                     'dimension_separator': '/',
                     'compressor': None,
                 }
@@ -183,7 +183,7 @@ print(root.to_flat())
         dtype='|u1',
         fill_value=0,
         order='C',
-        filters=[],
+        filters=None,
         dimension_separator='/',
         compressor=None,
     ),
@@ -223,7 +223,7 @@ print(GroupSpec.from_flat(tree).model_dump())
                             'dtype': '|u1',
                             'fill_value': 0,
                             'order': 'C',
-                            'filters': [],
+                            'filters': None,
                             'dimension_separator': '/',
                             'compressor': None,
                         }
@@ -376,7 +376,7 @@ print(ArraysOnlyGroup(attributes={}, members=items).model_dump())
             'dtype': '|u1',
             'fill_value': 0,
             'order': 'C',
-            'filters': [],
+            'filters': None,
             'dimension_separator': '/',
             'compressor': None,
         }

--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -64,14 +64,8 @@ spec_dict2['members']['bar']['shape'] = (100,)
 # serialize the spec to the store
 group2 = GroupSpec(**spec_dict2).to_zarr(grp.store, path='foo2')
 
-print(group2)
-#> <Group memory://4425345472/foo2>
-
 print(dict(group2.attrs))
 #> {'a': 100, 'b': 'metadata'}
-
-print(group2['bar'])
-#> <Array memory://4425345472/foo2/bar shape=(100,) dtype=float64>
 
 print(dict(group2['bar'].attrs))
 #> {'array_metadata': True}

--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -46,7 +46,7 @@ print(spec.model_dump())
             'order': 'C',
             'filters': [],
             'dimension_separator': '.',
-            'compressor': {'id': 'zstd', 'level': 0, 'checksum': False},
+            'compressor': None,
         }
     },
 }
@@ -90,7 +90,7 @@ print(ArraySpec.from_array(np.arange(10)).model_dump())
     'dtype': '<i8',
     'fill_value': 0,
     'order': 'C',
-    'filters': None,
+    'filters': [],
     'dimension_separator': '/',
     'compressor': None,
 }
@@ -143,7 +143,7 @@ print(GroupSpec.from_flat(tree).model_dump())
                     'dtype': '|u1',
                     'fill_value': 0,
                     'order': 'C',
-                    'filters': None,
+                    'filters': [],
                     'dimension_separator': '/',
                     'compressor': None,
                 }
@@ -183,7 +183,7 @@ print(root.to_flat())
         dtype='|u1',
         fill_value=0,
         order='C',
-        filters=None,
+        filters=[],
         dimension_separator='/',
         compressor=None,
     ),
@@ -223,7 +223,7 @@ print(GroupSpec.from_flat(tree).model_dump())
                             'dtype': '|u1',
                             'fill_value': 0,
                             'order': 'C',
-                            'filters': None,
+                            'filters': [],
                             'dimension_separator': '/',
                             'compressor': None,
                         }
@@ -269,7 +269,7 @@ arr_a_stored = arr_a.to_zarr(store, path='arr_a')
 
 # arr_a is like the zarr.Array version of itself
 print(arr_a.like(arr_a_stored))
-#> False
+#> True
 
 # Returns False, because of mismatched shape
 print(arr_b.like(arr_a_stored))
@@ -277,7 +277,7 @@ print(arr_b.like(arr_a_stored))
 
 # Returns True, because we exclude shape.
 print(arr_b.like(arr_a_stored, exclude={'shape'}))
-#> False
+#> True
 
 # The same thing, but for groups
 g_a = GroupSpec(attributes={'foo': 10}, members={'a': arr_a, 'b': arr_b})
@@ -297,7 +297,7 @@ print(g_a.like(g_b, exclude={'attributes'}))
 
 # g_a is like its zarr.Group counterpart
 print(g_a.like(g_a.to_zarr(store, path='g_a')))
-#> False
+#> True
 ```
 
 ## Using generic types
@@ -376,7 +376,7 @@ print(ArraysOnlyGroup(attributes={}, members=items).model_dump())
             'dtype': '|u1',
             'fill_value': 0,
             'order': 'C',
-            'filters': None,
+            'filters': [],
             'dimension_separator': '/',
             'compressor': None,
         }

--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -17,14 +17,16 @@ To write a hierarchy to some zarr-compatible storage backend, `GroupSpec` and `A
 Note that `to_zarr` will _not_ write any array data. You have to do this separately.
 
 ```python
-from zarr import group, create
-from zarr.storage import MemoryStore
+from zarr import create, group
+
 from pydantic_zarr.v2 import GroupSpec
 
 # create an in-memory Zarr group + array with attributes
-grp = group(path='foo')
+grp = group(path='foo', zarr_format=2)
 grp.attrs.put({'group_metadata': 10})
-arr = create(path='foo/bar', store=grp.store, shape=(10,), compressor=None, zarr_format=2)
+arr = create(
+    path='foo/bar', store=grp.store, shape=(10,), compressor=None, zarr_format=2
+)
 arr.attrs.put({'array_metadata': True})
 
 spec = GroupSpec.from_zarr(grp)
@@ -42,9 +44,9 @@ print(spec.model_dump())
             'dtype': '<f8',
             'fill_value': 0.0,
             'order': 'C',
-            'filters': None,
+            'filters': [],
             'dimension_separator': '.',
-            'compressor': None,
+            'compressor': {'id': 'zstd', 'level': 0, 'checksum': False},
         }
     },
 }
@@ -63,13 +65,13 @@ spec_dict2['members']['bar']['shape'] = (100,)
 group2 = GroupSpec(**spec_dict2).to_zarr(grp.store, path='foo2')
 
 print(group2)
-#> <zarr.hierarchy.Group '/foo2'>
+#> <Group memory://4425345472/foo2>
 
 print(dict(group2.attrs))
 #> {'a': 100, 'b': 'metadata'}
 
 print(group2['bar'])
-#> <zarr.core.Array '/foo2/bar' (100,) float64>
+#> <Array memory://4425345472/foo2/bar shape=(100,) dtype=float64>
 
 print(dict(group2['bar'].attrs))
 #> {'array_metadata': True}
@@ -80,8 +82,9 @@ print(dict(group2['bar'].attrs))
 The `ArraySpec` class has a `from_array` static method that takes an array-like object and returns an `ArraySpec` with `shape` and `dtype` fields matching those of the array-like object.
 
 ```python
-from pydantic_zarr.v2 import ArraySpec
 import numpy as np
+
+from pydantic_zarr.v2 import ArraySpec
 
 print(ArraySpec.from_array(np.arange(10)).model_dump())
 """
@@ -117,15 +120,16 @@ methods to convert to / from these dictionaries.
 This example demonstrates how to create a `GroupSpec` from a `dict` representation of a Zarr hierarchy.
 
 ```python
-from pydantic_zarr.v2 import GroupSpec, ArraySpec
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
+
 # other than the key representing the root path "",
 # the keys must be valid paths in the Zarr storage hierarchy
 # note that the `members` attribute is `None` for the `GroupSpec` instances in this `dict`.
 tree = {
     "": GroupSpec(members=None, attributes={"root": True}),
     "/a": GroupSpec(members=None, attributes={"root": False}),
-    "/a/b": ArraySpec(shape=(10,10), dtype="uint8", chunks=(1,1))
-    }
+    "/a/b": ArraySpec(shape=(10, 10), dtype="uint8", chunks=(1, 1)),
+}
 
 print(GroupSpec.from_flat(tree).model_dump())
 """
@@ -162,12 +166,13 @@ This is similar to the example above, except that we are working in reverse -- w
 flat `dict` from the `GroupSpec` object.
 
 ```python
-from pydantic_zarr.v2 import GroupSpec, ArraySpec
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
+
 # other than the key representing the root path "",
 # the keys must be valid paths in the Zarr storage hierarchy
 # note that the `members` attribute is `None` for the `GroupSpec` instances in this `dict`.
 
-a_b = ArraySpec(shape=(10,10), dtype="uint8", chunks=(1,1))
+a_b = ArraySpec(shape=(10, 10), dtype="uint8", chunks=(1, 1))
 a = GroupSpec(members={'b': a_b}, attributes={"root": False})
 root = GroupSpec(members={'a': a}, attributes={"root": True})
 
@@ -199,7 +204,8 @@ hierarchy without explicitly creating the intermediate groups first.
 `from_flat` models this behavior. For example, `{'/a/b/c': ArraySpec(...)}` implicitly defines the existence of a groups named `a` and `b` (which is contained in `a`). `from_flat` will create the expected `GroupSpec` object from such `dict` instances.
 
 ```python
-from pydantic_zarr.v2 import GroupSpec, ArraySpec
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
+
 tree = {'/a/b/c': ArraySpec(shape=(1,), dtype='uint8', chunks=(1,))}
 print(GroupSpec.from_flat(tree).model_dump())
 """
@@ -245,9 +251,10 @@ The `like` method works by converting both input models to `dict` via `pydantic.
 The `like` method takes keyword arguments `include` and `exclude`, which determine the attributes included or excluded from the model comparison. So it's possible to use `like` to check if two `ArraySpec` instances have the same `shape`, `dtype` and `chunks` by calling `array_a.like(array_b, include={'shape', 'dtype', 'chunks'})`. This is useful if you don't care about the compressor or filters and just want to ensure that you can safely write an in-memory array to a Zarr array, which depends just on the two arrays having matching `shape`, `dtype`, and `chunks` attributes.
 
 ```python
-from pydantic_zarr.v2 import ArraySpec, GroupSpec
 import zarr
 import zarr.storage
+
+from pydantic_zarr.v2 import ArraySpec, GroupSpec
 
 arr_a = ArraySpec(shape=(1,), dtype='uint8', chunks=(1,))
 # make an array with a different shape
@@ -268,7 +275,7 @@ arr_a_stored = arr_a.to_zarr(store, path='arr_a')
 
 # arr_a is like the zarr.Array version of itself
 print(arr_a.like(arr_a_stored))
-#> True
+#> False
 
 # Returns False, because of mismatched shape
 print(arr_b.like(arr_a_stored))
@@ -276,7 +283,7 @@ print(arr_b.like(arr_a_stored))
 
 # Returns True, because we exclude shape.
 print(arr_b.like(arr_a_stored, exclude={'shape'}))
-#> True
+#> False
 
 # The same thing, but for groups
 g_a = GroupSpec(attributes={'foo': 10}, members={'a': arr_a, 'b': arr_b})
@@ -296,7 +303,7 @@ print(g_a.like(g_b, exclude={'attributes'}))
 
 # g_a is like its zarr.Group counterpart
 print(g_a.like(g_a.to_zarr(store, path='g_a')))
-#> True
+#> False
 ```
 
 ## Using generic types
@@ -305,29 +312,32 @@ This example shows how to specialize `GroupSpec` and `ArraySpec` with type param
 
 ```python
 import sys
-from pydantic_zarr.v2 import GroupSpec, ArraySpec, TItem, TAttr
+
 from pydantic import ValidationError
-from typing import Any
+
+from pydantic_zarr.v2 import ArraySpec, GroupSpec, TAttr, TItem
 
 if sys.version_info < (3, 12):
     from typing_extensions import TypedDict
 else:
     from typing import TypedDict
 
+
 # a Pydantic BaseModel would also work here
 class GroupAttrs(TypedDict):
     a: int
     b: int
 
+
 # a Zarr group with attributes consistent with GroupAttrs
 SpecificAttrsGroup = GroupSpec[GroupAttrs, TItem]
 
 try:
-    SpecificAttrsGroup(attributes={'a' : 10, 'b': 'foo'})
+    SpecificAttrsGroup(attributes={'a': 10, 'b': 'foo'})
 except ValidationError as exc:
     print(exc)
     """
-    1 validation error for GroupSpec[GroupAttrs, ~TItem]
+    1 validation error for GroupSpec[GroupAttrs, TypeVar]
     attributes.b
       Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='foo', input_type=str]
         For further information visit https://errors.pydantic.dev/2.6/v/int_parsing
@@ -346,18 +356,18 @@ try:
 except ValidationError as exc:
     print(exc)
     """
-    1 validation error for GroupSpec[~TAttr, ArraySpec]
+    1 validation error for GroupSpec[TypeVar, ArraySpec]
     members.foo
       Input should be a valid dictionary or instance of ArraySpec [type=model_type, input_value=GroupSpec(zarr_format=2, ...tributes={}, members={}), input_type=GroupSpec]
         For further information visit https://errors.pydantic.dev/2.6/v/model_type
     """
 
 # this passes validation
-items = {'foo': ArraySpec(attributes={},
-                          shape=(1,),
-                          dtype='uint8',
-                          chunks=(1,),
-                          compressor=None)}
+items = {
+    'foo': ArraySpec(
+        attributes={}, shape=(1,), dtype='uint8', chunks=(1,), compressor=None
+    )
+}
 print(ArraysOnlyGroup(attributes={}, members=items).model_dump())
 """
 {

--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -331,7 +331,7 @@ try:
 except ValidationError as exc:
     print(exc)
     """
-    1 validation error for GroupSpec[GroupAttrs, TypeVar]
+    1 validation error for GroupSpec[GroupAttrs, ~TItem]
     attributes.b
       Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='foo', input_type=str]
         For further information visit https://errors.pydantic.dev/2.6/v/int_parsing
@@ -350,7 +350,7 @@ try:
 except ValidationError as exc:
     print(exc)
     """
-    1 validation error for GroupSpec[TypeVar, ArraySpec]
+    1 validation error for GroupSpec[~TAttr, ArraySpec]
     members.foo
       Input should be a valid dictionary or instance of ArraySpec [type=model_type, input_value=GroupSpec(zarr_format=2, ...tributes={}, members={}), input_type=GroupSpec]
         For further information visit https://errors.pydantic.dev/2.6/v/model_type

--- a/docs/usage_zarr_v3.md
+++ b/docs/usage_zarr_v3.md
@@ -12,7 +12,8 @@ the backend for that doesn't exist.
 ## Defining Zarr v3 hierarchies
 
 ```python
-from pydantic_zarr.v3 import GroupSpec, ArraySpec, NamedConfig
+from pydantic_zarr.v3 import ArraySpec, GroupSpec, NamedConfig
+
 array_attributes = {"baz": [1, 2, 3]}
 group_attributes = {"foo": 42, "bar": False}
 
@@ -21,12 +22,8 @@ array_spec = ArraySpec(
     shape=[1000, 1000],
     dimension_names=["rows", "columns"],
     data_type="uint8",
-    chunk_grid=NamedConfig(
-        name="regular", configuration={"chunk_shape": [1000, 100]}
-    ),
-    chunk_key_encoding=NamedConfig(
-        name="default", configuration={"separator": "/"}
-    ),
+    chunk_grid=NamedConfig(name="regular", configuration={"chunk_shape": [1000, 100]}),
+    chunk_key_encoding=NamedConfig(name="default", configuration={"separator": "/"}),
     codecs=[NamedConfig(name="GZip", configuration={"level": 1})],
     fill_value=0,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ Issues = "https://github.com/zarr-developers/pydantic-zarr/issues"
 Source = "https://github.com/zarr-developers/pydantic-zarr"
 
 [project.optional-dependencies]
-test = ["coverage", "pytest", "pytest-cov", "pytest-examples"]
+# pytest pin is due to https://github.com/pytest-dev/pytest-cov/issues/693
+test = ["coverage", "pytest<8.4", "pytest-cov", "pytest-examples"]
 
 docs = [
     "mkdocs-material",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,14 @@ keywords = ["zarr", "pydantic"]
 authors = [{ name = "Davis Bennett", email = "davis.v.bennett@gmail.com" }]
 maintainers = [{ name = "David Stansby" }]
 
+
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
-dependencies = ["zarr<3", "pydantic>2.0.0"]
-
+dependencies = ["zarr>=3", "pydantic>2.0.0"]
 [project.urls]
 Documentation = "https://zarr.dev/pydantic-zarr/"
 Issues = "https://github.com/zarr-developers/pydantic-zarr/issues"
@@ -170,7 +170,11 @@ xfail_strict = true
 testpaths = ["tests"]
 log_cli_level = "INFO"
 addopts = ["--durations=10", "-ra", "--strict-config", "--strict-markers"]
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    # https://github.com/zarr-developers/zarr-python/issues/2948
+    "ignore:The `order` keyword argument has no effect for Zarr format 3 arrays:RuntimeWarning",
+]
 
 [tool.repo-review]
 ignore = [

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -385,7 +385,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         if self.filters is not None:
             spec_dict["filters"] = [numcodecs.get_codec(f) for f in spec_dict["filters"]]
         if _contains_array(store, path):
-            extant_array = zarr.open_array(store, path=path, mode="r", zarr_format=2)
+            extant_array = zarr.open_array(store, path=path, zarr_format=2)
 
             if not self.like(extant_array):
                 if not overwrite:

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -390,7 +390,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
                     return zarr.open_array(
                         store=extant_array.store, path=extant_array.path, zarr_format=2, **kwargs
                     )
-        spec_dict["zarr_format"] = 2
+        spec_dict["zarr_format"] = spec_dict.pop("zarr_version", 2)
         result = zarr.create(store=store, path=path, overwrite=overwrite, **spec_dict, **kwargs)
         result.attrs.put(attrs)
         return result

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -390,7 +390,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
                     return zarr.open_array(
                         store=extant_array.store, path=extant_array.path, zarr_format=2, **kwargs
                     )
-        spec_dict["zarr_format"] = spec_dict.pop("zarr_version", 2)
+        spec_dict["zarr_format"] = 2
         result = zarr.create(store=store, path=path, overwrite=overwrite, **spec_dict, **kwargs)
         result.attrs.put(attrs)
         return result
@@ -564,7 +564,7 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
         spec_dict = self.model_dump(exclude={"members": True})
         attrs = spec_dict.pop("attributes")
         if _contains_group(store, path):
-            extant_group = zarr.group(store, path=path)
+            extant_group = zarr.group(store, path=path, zarr_format=2)
             if not self.like(extant_group):
                 if not overwrite:
                     msg = (
@@ -588,7 +588,7 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
         else:
             zarr.create_group(store=store, overwrite=overwrite, path=path, zarr_format=2)
 
-        result = zarr.group(store=store, path=path, overwrite=overwrite)
+        result = zarr.group(store=store, path=path, overwrite=overwrite, zarr_format=2)
         result.attrs.put(attrs)
         # consider raising an exception if a partial GroupSpec is provided
         if self.members is not None:

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -515,7 +515,8 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
         if depth == 0:
             return cls(attributes=attributes, members=None)
         new_depth = max(depth - 1, -1)
-        for name, item in group.items():
+        for name in group:
+            item = group[name]
             if isinstance(item, zarr.Array):
                 # convert to dict before the final typed GroupSpec construction
                 item_out = ArraySpec.from_zarr(item).model_dump()

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -48,7 +48,10 @@ def _contains_array(store: Store, path: str) -> bool:
 
 
 def _contains_group(store: Store, path: str) -> bool:
-    return isinstance(get_node(store, path, zarr_format=2), zarr.Group)
+    try:
+        return isinstance(get_node(store, path, zarr_format=2), zarr.Group)
+    except FileNotFoundError:
+        return False
 
 
 def stringify_dtype(value: npt.DTypeLike) -> str:

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -21,7 +21,7 @@ import numpy as np
 import numpy.typing as npt
 import zarr
 from numcodecs.abc import Codec
-from pydantic import AfterValidator, Field, model_validator
+from pydantic import AfterValidator, field_validator, model_validator
 from pydantic.functional_validators import BeforeValidator
 from zarr.core.sync_group import get_node
 from zarr.errors import ContainsArrayError, ContainsGroupError
@@ -177,11 +177,19 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
     dtype: DtypeStr
     fill_value: int | float | None = 0
     order: Literal["C", "F"] = "C"
-    filters: list[CodecDict] = Field(default=[])
+    filters: list[CodecDict] | None = None
     dimension_separator: Annotated[
         Literal["/", "."], BeforeValidator(parse_dimension_separator)
     ] = "/"
     compressor: CodecDict | None = None
+
+    @field_validator("filters", mode="after")
+    @classmethod
+    def validate_filters(cls, value: list[CodecDict] | None) -> list[CodecDict] | None:
+        # Make sure filters is never an empty list
+        if value == []:
+            return None
+        return value
 
     @model_validator(mode="after")
     def check_ndim(self) -> Self:
@@ -251,7 +259,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         >>> import numpy as np
         >>> x = ArraySpec.from_array(np.arange(10))
         >>> x
-        ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=[], dimension_separator='/', compressor=None)
+        ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=None, dimension_separator='/', compressor=None)
 
 
         """
@@ -325,7 +333,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         >>> from pydantic_zarr.v2 import ArraySpec
         >>> x = zarr.create((10,10))
         >>> ArraySpec.from_zarr(x)
-        ArraySpec(zarr_format=2, attributes={}, shape=(10, 10), chunks=(10, 10), dtype='<f8', fill_value=0.0, order='C', filters=[], dimension_separator='.', compressor={'id': 'blosc', 'cname': 'lz4', 'clevel': 5, 'shuffle': 1, 'blocksize': 0})
+        ArraySpec(zarr_format=2, attributes={}, shape=(10, 10), chunks=(10, 10), dtype='<f8', fill_value=0.0, order='C', filters=None, dimension_separator='.', compressor={'id': 'blosc', 'cname': 'lz4', 'clevel': 5, 'shuffle': 1, 'blocksize': 0})
 
         """
         return cls(
@@ -722,7 +730,7 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
             '': GroupSpec(attributes={'foo': 10}, members=None),
             '/a': ArraySpec.from_array(np.arange(10))}
         >>> GroupSpec.from_flat(flat)
-        GroupSpec(zarr_format=2, attributes={'foo': 10}, members={'a': ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=[], dimension_separator='/', compressor=None)})
+        GroupSpec(zarr_format=2, attributes={'foo': 10}, members={'a': ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=None, dimension_separator='/', compressor=None)})
         """
         from_flated = from_flat_group(data)
         return cls(**from_flated.model_dump())
@@ -896,10 +904,10 @@ def from_flat(data: dict[str, ArraySpec | GroupSpec]) -> ArraySpec | GroupSpec:
     >>> import numpy as np
     >>> tree = {'': ArraySpec.from_array(np.arange(10))}
     >>> from_flat(tree) # special case of a Zarr array at the root of the hierarchy
-    ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=[], dimension_separator='/', compressor=None)
+    ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=None, dimension_separator='/', compressor=None)
     >>> tree = {'/foo': ArraySpec.from_array(np.arange(10))}
     >>> from_flat(tree) # note that an implicit Group is created
-    GroupSpec(zarr_format=2, attributes={}, members={'foo': ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=[], dimension_separator='/', compressor=None)})
+    GroupSpec(zarr_format=2, attributes={}, members={'foo': ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=None, dimension_separator='/', compressor=None)})
     """
 
     # minimal check that the keys are valid
@@ -935,7 +943,7 @@ def from_flat_group(data: dict[str, ArraySpec | GroupSpec]) -> GroupSpec:
     >>> import numpy as np
     >>> tree = {'/foo': ArraySpec.from_array(np.arange(10))}
     >>> from_flat_group(tree) # note that an implicit Group is created
-    GroupSpec(zarr_format=2, attributes={}, members={'foo': ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=[], dimension_separator='/', compressor=None)})
+    GroupSpec(zarr_format=2, attributes={}, members={'foo': ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=None, dimension_separator='/', compressor=None)})
     """
     root_name = ""
     sep = "/"
@@ -1035,13 +1043,13 @@ def auto_compresser(data: Any) -> Codec | None:
     return None
 
 
-def auto_filters(data: Any) -> list[Codec]:
+def auto_filters(data: Any) -> list[Codec] | None:
     """
     Guess filters from an input with a `filters` attribute, returning `None` otherwise.
     """
     if hasattr(data, "filters"):
         return data.filters
-    return []
+    return None
 
 
 def auto_order(data: Any) -> Literal["C", "F"]:

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -40,6 +40,8 @@ TAttr = TypeVar("TAttr", bound=Mapping[str, Any])
 TItem = TypeVar("TItem", bound=Union["GroupSpec", "ArraySpec"])  # type: ignore[type-arg]
 
 
+# TODO: expose contains_array and contains_group as public functions in zarr-python
+# and replace these custom implementations
 def _contains_array(store: Store, path: str) -> bool:
     try:
         return isinstance(get_node(store, path, zarr_format=2), zarr.Array)

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -328,6 +328,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         ArraySpec(zarr_format=2, attributes={}, shape=(10, 10), chunks=(10, 10), dtype='<f8', fill_value=0.0, order='C', filters=None, dimension_separator='.', compressor={'id': 'blosc', 'cname': 'lz4', 'clevel': 5, 'shuffle': 1, 'blocksize': 0})
 
         """
+        filters = array.filters if len(array.filters) else None
         return cls(
             shape=array.shape,
             chunks=array.chunks,
@@ -336,7 +337,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
             # so that int 0 isn't serialized as 0.0
             fill_value=array.dtype.type(array.fill_value).tolist(),
             order=array.order,
-            filters=array.filters,
+            filters=filters,
             dimension_separator=array.metadata.dimension_separator,
             compressor=array.compressors[0].get_config(),
             attributes=array.attrs.asdict(),

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -212,7 +212,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         attributes: Literal["auto"] | TAttr = "auto",
         fill_value: Literal["auto"] | float | None = "auto",
         order: Literal["auto", "C", "F"] = "auto",
-        filters: Literal["auto"] | list[CodecDict] = "auto",
+        filters: Literal["auto"] | list[CodecDict] | None = "auto",
         dimension_separator: Literal["auto", "/", "."] = "auto",
         compressor: Literal["auto"] | CodecDict | None = "auto",
     ) -> Self:

--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -204,7 +204,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         attributes: Literal["auto"] | TAttr = "auto",
         fill_value: Literal["auto"] | float | None = "auto",
         order: Literal["auto", "C", "F"] = "auto",
-        filters: Literal["auto"] | list[CodecDict] | None = "auto",
+        filters: Literal["auto"] | list[CodecDict] = "auto",
         dimension_separator: Literal["auto", "/", "."] = "auto",
         compressor: Literal["auto"] | CodecDict | None = "auto",
     ) -> Self:
@@ -328,7 +328,6 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         ArraySpec(zarr_format=2, attributes={}, shape=(10, 10), chunks=(10, 10), dtype='<f8', fill_value=0.0, order='C', filters=None, dimension_separator='.', compressor={'id': 'blosc', 'cname': 'lz4', 'clevel': 5, 'shuffle': 1, 'blocksize': 0})
 
         """
-        filters = array.filters if len(array.filters) else None
         return cls(
             shape=array.shape,
             chunks=array.chunks,
@@ -337,7 +336,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
             # so that int 0 isn't serialized as 0.0
             fill_value=array.dtype.type(array.fill_value).tolist(),
             order=array.order,
-            filters=filters,
+            filters=array.filters,
             dimension_separator=array.metadata.dimension_separator,
             compressor=array.compressors[0].get_config(),
             attributes=array.attrs.asdict(),
@@ -897,7 +896,7 @@ def from_flat(data: dict[str, ArraySpec | GroupSpec]) -> ArraySpec | GroupSpec:
     >>> import numpy as np
     >>> tree = {'': ArraySpec.from_array(np.arange(10))}
     >>> from_flat(tree) # special case of a Zarr array at the root of the hierarchy
-    ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=None, dimension_separator='/', compressor=None)
+    ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=[], dimension_separator='/', compressor=None)
     >>> tree = {'/foo': ArraySpec.from_array(np.arange(10))}
     >>> from_flat(tree) # note that an implicit Group is created
     GroupSpec(zarr_format=2, attributes={}, members={'foo': ArraySpec(zarr_format=2, attributes={}, shape=(10,), chunks=(10,), dtype='<i8', fill_value=0, order='C', filters=None, dimension_separator='/', compressor=None)})

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -15,6 +15,8 @@ from typing import (
     overload,
 )
 
+import numpy.typing as npt
+import zarr
 from pydantic import BeforeValidator
 
 from pydantic_zarr.core import StrictBase
@@ -23,7 +25,7 @@ from pydantic_zarr.v2 import stringify_dtype
 if TYPE_CHECKING:
     import numpy.typing as npt
     import zarr
-    from zarr.storage import BaseStore
+    from zarr.abc.store import Store
 
 
 TAttr = TypeVar("TAttr", bound=dict[str, Any])
@@ -169,13 +171,13 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         """
         raise NotImplementedError
 
-    def to_zarr(self, store: BaseStore, path: str, overwrite: bool = False) -> zarr.Array:
+    def to_zarr(self, store: Store, path: str, overwrite: bool = False) -> zarr.Array:
         """
         Serialize an ArraySpec to a zarr array at a specific path in a zarr store.
 
         Parameters
         ----------
-        store : instance of zarr.BaseStore
+        store : instance of zarr.abc.store.Store
             The storage backend that will manifest the array.
         path : str
             The location of the array inside the store.
@@ -232,13 +234,13 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
 
         raise NotImplementedError
 
-    def to_zarr(self, store: BaseStore, path: str, overwrite: bool = False) -> Never:
+    def to_zarr(self, store: Store, path: str, overwrite: bool = False) -> Never:
         """
         Serialize a GroupSpec to a zarr group at a specific path in a zarr store.
 
         Parameters
         ----------
-        store : instance of zarr.BaseStore
+        store : instance of zarr.abc.store.Store
             The storage backend that will manifest the group and its contents.
         path : str
             The location of the group inside the store.
@@ -270,7 +272,7 @@ def from_zarr(element: zarr.Array | zarr.Group) -> ArraySpec | GroupSpec:
     Recursively parse a Zarr group or Zarr array into an ArraySpec or GroupSpec.
 
     Parameters
-    ---------
+    ----------
     element : a zarr Array or zarr Group
 
     Returns
@@ -285,7 +287,7 @@ def from_zarr(element: zarr.Array | zarr.Group) -> ArraySpec | GroupSpec:
 @overload
 def to_zarr(
     spec: ArraySpec,
-    store: BaseStore,
+    store: Store,
     path: str,
     overwrite: bool = False,
 ) -> zarr.Array: ...
@@ -294,7 +296,7 @@ def to_zarr(
 @overload
 def to_zarr(
     spec: GroupSpec,
-    store: BaseStore,
+    store: Store,
     path: str,
     overwrite: bool = False,
 ) -> zarr.Group: ...
@@ -302,7 +304,7 @@ def to_zarr(
 
 def to_zarr(
     spec: ArraySpec | GroupSpec,
-    store: BaseStore,
+    store: Store,
     path: str,
     overwrite: bool = False,
 ) -> zarr.Array | zarr.Group:
@@ -314,7 +316,7 @@ def to_zarr(
     ----------
     spec : GroupSpec or ArraySpec
         The GroupSpec or ArraySpec that will be serialized to storage.
-    store : instance of zarr.BaseStore
+    store : instance of zarr.abc.store.Store
         The storage backend that will manifest the group or array.
     path : str
         The location of the group or array inside the store.

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -4,9 +4,20 @@ Testts for pydantic_zarr.v2.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import zarr
+import zarr.storage
+from pydantic import ValidationError
+from zarr.errors import ContainsArrayError, ContainsGroupError
+
+if TYPE_CHECKING:
+    from typing import Literal
+
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from numcodecs.abc import Codec
@@ -14,11 +25,8 @@ if TYPE_CHECKING:
 import numcodecs
 import numpy as np
 import numpy.typing as npt
-import pytest
 import zarr
 from numcodecs import GZip
-from pydantic import ValidationError
-from zarr.errors import ContainsArrayError, ContainsGroupError
 
 from pydantic_zarr.v2 import (
     ArraySpec,
@@ -45,7 +53,8 @@ ArrayMemoryOrder = Literal["C", "F"]
 DimensionSeparator = Literal[".", "/"]
 
 
-@pytest.fixture(params=("C", "F"), ids=["C", "F"])
+# TODO: also test "F"; see https://github.com/zarr-developers/zarr-python/issues/2950
+@pytest.fixture(params=("C"), ids=["C"])
 def memory_order(request: pytest.FixtureRequest) -> ArrayMemoryOrder:
     """
     Fixture that returns either "C" or "F"
@@ -85,7 +94,7 @@ def test_array_spec(
     compressor: Codec | None,
     filters: tuple[str, ...] | None,
 ) -> None:
-    store = zarr.MemoryStore()
+    store = zarr.storage.MemoryStore()
     _filters: list[Codec] | None
     if filters is not None:
         _filters = []
@@ -107,17 +116,18 @@ def test_array_spec(
         dimension_separator=dimension_separator,
         compressor=compressor,
         filters=_filters,
+        zarr_format=2,
     )
     attributes = {"foo": [100, 200, 300], "bar": "hello"}
     array.attrs.put(attributes)
     spec = ArraySpec.from_zarr(array)
 
-    assert spec.zarr_format == array._version
+    assert spec.zarr_format == array.metadata.zarr_format
     assert spec.dtype == array.dtype
     assert spec.attributes == array.attrs
     assert spec.chunks == array.chunks
 
-    assert spec.dimension_separator == array._dimension_separator
+    assert spec.dimension_separator == array.metadata.dimension_separator
     assert spec.shape == array.shape
     assert spec.fill_value == array.fill_value
     # this is a sign that nullability is being misused in zarr-python
@@ -127,36 +137,36 @@ def test_array_spec(
     else:
         assert spec.filters == array.filters
 
-    if array.compressor is not None:
-        assert spec.compressor == array.compressor.get_config()
+    if array.compressors is not None:
+        assert spec.compressor == array.compressors[0].get_config()
     else:
-        assert spec.compressor == array.compressor
+        assert spec.compressor == array.compressors[0]
 
     assert spec.order == array.order
 
     array2 = spec.to_zarr(store, "foo2")
 
-    assert spec.zarr_format == array2._version
+    assert spec.zarr_format == array2.metadata.zarr_format
     assert spec.dtype == array2.dtype
     assert spec.attributes == array2.attrs
     assert spec.chunks == array2.chunks
 
-    if array2.compressor is not None:
-        assert spec.compressor == array2.compressor.get_config()
+    if array2.compressors is not None:
+        assert spec.compressor == array2.compressors[0].get_config()
     else:
-        assert spec.compressor == array2.compressor
+        assert spec.compressor == array2.compressors[0]
 
     if array2.filters is not None:
         assert spec.filters == [f.get_config() for f in array2.filters]
     else:
         assert spec.filters == array2.filters
 
-    assert spec.dimension_separator == array2._dimension_separator
+    assert spec.dimension_separator == array2.metadata.dimension_separator
     assert spec.shape == array2.shape
     assert spec.fill_value == array2.fill_value
 
     # test serialization
-    store = zarr.MemoryStore()
+    store = zarr.storage.MemoryStore()
     stored = spec.to_zarr(store, path="foo")
     assert ArraySpec.from_zarr(stored) == spec
 
@@ -174,9 +184,19 @@ def test_array_spec(
 
     # test that mode and write_empty_chunks get passed through
     assert spec_2.to_zarr(store, path="foo", mode="a").read_only is False
-    assert spec_2.to_zarr(store, path="foo", mode="r").read_only is True
-    assert spec_2.to_zarr(store, path="foo", write_empty_chunks=False)._write_empty_chunks is False
-    assert spec_2.to_zarr(store, path="foo", write_empty_chunks=True)._write_empty_chunks is True
+    # TODO: uncomment line below when https://github.com/zarr-developers/zarr-python/issues/2949 is fixed
+    # assert spec_2.to_zarr(store, path="foo", mode="r").read_only is True
+    # TODO: work out if there's a way to get the status of "write_empty_chunks" from an array
+    """
+    assert (
+        spec_2.to_zarr(store, path="foo", config={"write_empty_chunks": False})._write_empty_chunks
+        is False
+    )
+    assert (
+        spec_2.to_zarr(store, path="foo", config={"write_empty_chunks": True})._write_empty_chunks
+        is True
+    )
+    """
 
 
 @dataclass
@@ -328,7 +348,7 @@ def test_serialize_deserialize_groupspec(
     class ArrayAttrs(TypedDict):
         scale: list[float]
 
-    store = zarr.MemoryStore()
+    store = zarr.storage.MemoryStore()
 
     spec = GroupSpec[RootAttrs, ArraySpec | SubGroup](
         attributes=RootAttrs(foo=10, bar=[0, 1, 2]),
@@ -423,7 +443,7 @@ def test_validation() -> None:
     GroupA = GroupSpec[GroupAttrsA, ArrayA]
     GroupB = GroupSpec[GroupAttrsB, ArrayB]
 
-    store = zarr.MemoryStore
+    store = zarr.storage.MemoryStore
 
     specA = GroupA(
         attributes=GroupAttrsA(group_a=True),
@@ -456,7 +476,7 @@ def test_validation() -> None:
             members={},
         )
 
-    store = zarr.MemoryStore()
+    store = zarr.storage.MemoryStore()
     groupAMat = specA.to_zarr(store, path="group_a")
     groupBMat = specB.to_zarr(store, path="group_b")
 
@@ -596,7 +616,7 @@ def test_from_zarr_depth() -> None:
         "/1/2/2": ArraySpec.from_array(np.arange(20), attributes={"level": 3, "type": "array"}),
     }
 
-    store = zarr.MemoryStore()
+    store = zarr.storage.MemoryStore()
     group_out = GroupSpec.from_flat(tree).to_zarr(store, path="test")
     group_in_0 = GroupSpec.from_zarr(group_out, depth=0)  # type: ignore[var-annotated]
     assert group_in_0 == tree[""]

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -182,9 +182,7 @@ def test_array_spec(
     assert ArraySpec.from_zarr(stored_2) == spec_2
 
     # test that mode and write_empty_chunks get passed through
-    assert spec_2.to_zarr(store, path="foo", mode="a").read_only is False
-    # TODO: uncomment line below when https://github.com/zarr-developers/zarr-python/issues/2949 is fixed
-    # assert spec_2.to_zarr(store, path="foo", mode="r").read_only is True
+    assert spec_2.to_zarr(store, path="foo").read_only is False
     # TODO: work out if there's a way to get the status of "write_empty_chunks" from an array
     """
     assert (

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -181,19 +181,7 @@ def test_array_spec(
     stored_2 = spec_2.to_zarr(store, path="foo", overwrite=True)
     assert ArraySpec.from_zarr(stored_2) == spec_2
 
-    # test that mode and write_empty_chunks get passed through
     assert spec_2.to_zarr(store, path="foo").read_only is False
-    # TODO: work out if there's a way to get the status of "write_empty_chunks" from an array
-    """
-    assert (
-        spec_2.to_zarr(store, path="foo", config={"write_empty_chunks": False})._write_empty_chunks
-        is False
-    )
-    assert (
-        spec_2.to_zarr(store, path="foo", config={"write_empty_chunks": True})._write_empty_chunks
-        is True
-    )
-    """
 
 
 @dataclass

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -132,10 +132,7 @@ def test_array_spec(
     assert spec.fill_value == array.fill_value
     # this is a sign that nullability is being misused in zarr-python
     # the correct approach would be to use an empty list to express "no filters".
-    if array.filters is not None:
-        assert spec.filters == [f.get_config() for f in array.filters]
-    else:
-        assert spec.filters == array.filters
+    assert spec.filters == [f.get_config() for f in array.filters]
 
     if array.compressors is not None:
         assert spec.compressor == array.compressors[0].get_config()
@@ -313,9 +310,7 @@ def test_array_spec_from_array(
 @pytest.mark.parametrize("dtype", ["bool", "uint8", np.dtype("uint8"), "float64"])
 @pytest.mark.parametrize("dimension_separator", [".", "/"])
 @pytest.mark.parametrize("compressor", [numcodecs.LZMA().get_config(), numcodecs.GZip()])
-@pytest.mark.parametrize(
-    "filters", [None, ("delta",), ("scale_offset",), ("delta", "scale_offset")]
-)
+@pytest.mark.parametrize("filters", [(), ("delta",), ("scale_offset",), ("delta", "scale_offset")])
 def test_serialize_deserialize_groupspec(
     chunks: tuple[int, ...],
     memory_order: ArrayMemoryOrder,

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -387,7 +387,7 @@ def test_serialize_deserialize_groupspec(
     assert observed == spec
 
     # assert that we get the same group twice
-    assert to_zarr(spec, store, "/group_a") == group
+    assert to_zarr(spec, store, "/group_a", overwrite=True) == group
 
     # check that we can't call to_zarr targeting the original group with a different spec
     spec_2 = spec.model_copy(update={"attributes": RootAttrs(foo=99, bar=[0, 1, 2])})
@@ -395,9 +395,10 @@ def test_serialize_deserialize_groupspec(
         _ = to_zarr(spec_2, store, "/group_a")
 
     # check that we can't call to_zarr with the original spec if the group has changed
-    group.attrs.put({"foo": 100})
+    group.attrs["foo"] = 100
     with pytest.raises(ContainsGroupError):
         _ = to_zarr(spec, store, "/group_a")
+    group.attrs["foo"] = 10
 
     # materialize again with overwrite
     group2 = to_zarr(spec, store, "/group_a", overwrite=True)

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -53,8 +53,7 @@ ArrayMemoryOrder = Literal["C", "F"]
 DimensionSeparator = Literal[".", "/"]
 
 
-# TODO: also test "F"; see https://github.com/zarr-developers/zarr-python/issues/2950
-@pytest.fixture(params=("C"), ids=["C"])
+@pytest.fixture(params=("C", "F"), ids=["C", "F"])
 def memory_order(request: pytest.FixtureRequest) -> ArrayMemoryOrder:
     """
     Fixture that returns either "C" or "F"

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -132,7 +132,10 @@ def test_array_spec(
     assert spec.fill_value == array.fill_value
     # this is a sign that nullability is being misused in zarr-python
     # the correct approach would be to use an empty list to express "no filters".
-    assert spec.filters == [f.get_config() for f in array.filters]
+    if len(array.filters):
+        assert spec.filters == [f.get_config() for f in array.filters]
+    else:
+        assert spec.filters is None
 
     if len(array.compressors):
         assert spec.compressor == array.compressors[0].get_config()
@@ -153,10 +156,10 @@ def test_array_spec(
     else:
         assert spec.compressor is None
 
-    if array2.filters is not None:
+    if len(array2.filters):
         assert spec.filters == [f.get_config() for f in array2.filters]
     else:
-        assert spec.filters == array2.filters
+        assert spec.filters is None
 
     assert spec.dimension_separator == array2.metadata.dimension_separator
     assert spec.shape == array2.shape
@@ -293,7 +296,7 @@ def test_array_spec_from_array(
     if filters in auto_options:
         assert spec.filters == auto_filters(array)
     else:
-        assert spec.filters == filters
+        assert spec.filters is None
 
     if dimension_separator in auto_options:
         assert spec.dimension_separator == auto_dimension_separator(array)

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -584,8 +584,6 @@ def test_array_like_with_zarr() -> None:
     arr = ArraySpec(shape=(1,), dtype="uint8", chunks=(1,))
     store = zarr.storage.MemoryStore()
     arr_stored = arr.to_zarr(store, path="arr")
-    print(arr)
-    print(ArraySpec.from_zarr(arr_stored))
     assert arr.like(arr_stored)
 
 

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -134,10 +134,10 @@ def test_array_spec(
     # the correct approach would be to use an empty list to express "no filters".
     assert spec.filters == [f.get_config() for f in array.filters]
 
-    if array.compressors is not None:
+    if len(array.compressors):
         assert spec.compressor == array.compressors[0].get_config()
     else:
-        assert spec.compressor == array.compressors[0]
+        assert spec.compressor is None
 
     assert spec.order == array.order
 
@@ -148,10 +148,10 @@ def test_array_spec(
     assert spec.attributes == array2.attrs
     assert spec.chunks == array2.chunks
 
-    if array2.compressors is not None:
+    if len(array2.compressors):
         assert spec.compressor == array2.compressors[0].get_config()
     else:
-        assert spec.compressor == array2.compressors[0]
+        assert spec.compressor is None
 
     if array2.filters is not None:
         assert spec.filters == [f.get_config() for f in array2.filters]
@@ -584,6 +584,8 @@ def test_array_like_with_zarr() -> None:
     arr = ArraySpec(shape=(1,), dtype="uint8", chunks=(1,))
     store = zarr.storage.MemoryStore()
     arr_stored = arr.to_zarr(store, path="arr")
+    print(arr)
+    print(ArraySpec.from_zarr(arr_stored))
     assert arr.like(arr_stored)
 
 


### PR DESCRIPTION
This switches exisiting code from `zarr-python` 2 to `zarr-python` 3, which is part of fixing https://github.com/zarr-developers/pydantic-zarr/issues/33.