### PR TITLE
Add test for .like() with a zarr Array

### DIFF
--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -564,6 +564,13 @@ def test_array_like() -> None:
     assert a.like(c, include={"dtype"})
 
 
+def test_array_like_with_zarr() -> None:
+    arr = ArraySpec(shape=(1,), dtype="uint8", chunks=(1,))
+    store = zarr.storage.MemoryStore()
+    arr_stored = arr.to_zarr(store, path="arr")
+    assert arr.like(arr_stored)
+
+
 # todo: parametrize
 def test_group_like() -> None:
     tree = {


### PR DESCRIPTION
I forget why I added this to https://github.com/zarr-developers/pydantic-zarr/pull/49, but I think it's to illustrate something that passes fine (as expected) currently, but fails with `zarr-python` 3. As such, I thought it was worth opening this as a standalone PR to add this extra test, given it passes currently.