### PR TITLE
zarr_version -> zarr_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ spec = GroupSpec.from_zarr(group)
 print(spec.model_dump())
 """
 {
-    'zarr_version': 2,
+    'zarr_format': 2,
     'attributes': {},
     'members': {
         'bar': {
-            'zarr_version': 2,
+            'zarr_format': 2,
             'attributes': {'metadata': 'hello'},
             'shape': (10,),
             'chunks': (10,),

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,11 +24,11 @@ spec = GroupSpec.from_zarr(group)
 print(spec.model_dump())
 """
 {
-    'zarr_version': 2,
+    'zarr_format': 2,
     'attributes': {},
     'members': {
         'bar': {
-            'zarr_version': 2,
+            'zarr_format': 2,
             'attributes': {'metadata': 'hello'},
             'shape': (10,),
             'chunks': (10,),

--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -32,11 +32,11 @@ spec = GroupSpec.from_zarr(grp)
 print(spec.model_dump())
 """
 {
-    'zarr_version': 2,
+    'zarr_format': 2,
     'attributes': {'group_metadata': 10},
     'members': {
         'bar': {
-            'zarr_version': 2,
+            'zarr_format': 2,
             'attributes': {'array_metadata': True},
             'shape': (10,),
             'chunks': (10,),
@@ -87,7 +87,7 @@ import numpy as np
 print(ArraySpec.from_array(np.arange(10)).model_dump())
 """
 {
-    'zarr_version': 2,
+    'zarr_format': 2,
     'attributes': {},
     'shape': (10,),
     'chunks': (10,),
@@ -130,15 +130,15 @@ tree = {
 print(GroupSpec.from_flat(tree).model_dump())
 """
 {
-    'zarr_version': 2,
+    'zarr_format': 2,
     'attributes': {'root': True},
     'members': {
         'a': {
-            'zarr_version': 2,
+            'zarr_format': 2,
             'attributes': {'root': False},
             'members': {
                 'b': {
-                    'zarr_version': 2,
+                    'zarr_format': 2,
                     'attributes': {},
                     'shape': (10, 10),
                     'chunks': (1, 1),
@@ -174,10 +174,10 @@ root = GroupSpec(members={'a': a}, attributes={"root": True})
 print(root.to_flat())
 """
 {
-    '': GroupSpec(zarr_version=2, attributes={'root': True}, members=None),
-    '/a': GroupSpec(zarr_version=2, attributes={'root': False}, members=None),
+    '': GroupSpec(zarr_format=2, attributes={'root': True}, members=None),
+    '/a': GroupSpec(zarr_format=2, attributes={'root': False}, members=None),
     '/a/b': ArraySpec(
-        zarr_version=2,
+        zarr_format=2,
         attributes={},
         shape=(10, 10),
         chunks=(1, 1),
@@ -203,19 +203,19 @@ tree = {'/a/b/c': ArraySpec(shape=(1,), dtype='uint8', chunks=(1,))}
 print(GroupSpec.from_flat(tree).model_dump())
 """
 {
-    'zarr_version': 2,
+    'zarr_format': 2,
     'attributes': {},
     'members': {
         'a': {
-            'zarr_version': 2,
+            'zarr_format': 2,
             'attributes': {},
             'members': {
                 'b': {
-                    'zarr_version': 2,
+                    'zarr_format': 2,
                     'attributes': {},
                     'members': {
                         'c': {
-                            'zarr_version': 2,
+                            'zarr_format': 2,
                             'attributes': {},
                             'shape': (1,),
                             'chunks': (1,),
@@ -327,12 +327,12 @@ except ValidationError as exc:
     1 validation error for GroupSpec[GroupAttrs, ~TItem]
     attributes.b
       Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='foo', input_type=str]
-        For further information visit https://errors.pydantic.dev/2.6/v/int_parsing
+        For further information visit https://errors.pydantic.dev/2.11/v/int_parsing
     """
 
 # this passes validation
 print(SpecificAttrsGroup(attributes={'a': 100, 'b': 100}))
-#> zarr_version=2 attributes={'a': 100, 'b': 100} members={}
+#> zarr_format=2 attributes={'a': 100, 'b': 100} members={}
 
 # a Zarr group that only contains arrays -- no subgroups!
 # we reuse the TAttr type variable defined in pydantic_zarr.core
@@ -345,8 +345,8 @@ except ValidationError as exc:
     """
     1 validation error for GroupSpec[~TAttr, ArraySpec]
     members.foo
-      Input should be a valid dictionary or instance of ArraySpec [type=model_type, input_value=GroupSpec(zarr_version=2,...tributes={}, members={}), input_type=GroupSpec]
-        For further information visit https://errors.pydantic.dev/2.6/v/model_type
+      Input should be a valid dictionary or instance of ArraySpec [type=model_type, input_value=GroupSpec(zarr_format=2, ...tributes={}, members={}), input_type=GroupSpec]
+        For further information visit https://errors.pydantic.dev/2.11/v/model_type
     """
 
 # this passes validation
@@ -358,11 +358,11 @@ items = {'foo': ArraySpec(attributes={},
 print(ArraysOnlyGroup(attributes={}, members=items).model_dump())
 """
 {
-    'zarr_version': 2,
+    'zarr_format': 2,
     'attributes': {},
     'members': {
         'foo': {
-            'zarr_version': 2,
+            'zarr_format': 2,
             'attributes': {},
             'shape': (1,),
             'chunks': (1,),

--- a/docs/usage_zarr_v2.md
+++ b/docs/usage_zarr_v2.md
@@ -327,7 +327,7 @@ except ValidationError as exc:
     1 validation error for GroupSpec[GroupAttrs, ~TItem]
     attributes.b
       Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='foo', input_type=str]
-        For further information visit https://errors.pydantic.dev/2.11/v/int_parsing
+        For further information visit https://errors.pydantic.dev/2.6/v/int_parsing
     """
 
 # this passes validation
@@ -346,7 +346,7 @@ except ValidationError as exc:
     1 validation error for GroupSpec[~TAttr, ArraySpec]
     members.foo
       Input should be a valid dictionary or instance of ArraySpec [type=model_type, input_value=GroupSpec(zarr_format=2, ...tributes={}, members={}), input_type=GroupSpec]
-        For further information visit https://errors.pydantic.dev/2.11/v/model_type
+        For further information visit https://errors.pydantic.dev/2.6/v/model_type
     """
 
 # this passes validation

--- a/tests/test_pydantic_zarr/test_v2.py
+++ b/tests/test_pydantic_zarr/test_v2.py
@@ -112,7 +112,7 @@ def test_array_spec(
     array.attrs.put(attributes)
     spec = ArraySpec.from_zarr(array)
 
-    assert spec.zarr_version == array._version
+    assert spec.zarr_format == array._version
     assert spec.dtype == array.dtype
     assert spec.attributes == array.attrs
     assert spec.chunks == array.chunks
@@ -136,7 +136,7 @@ def test_array_spec(
 
     array2 = spec.to_zarr(store, "foo2")
 
-    assert spec.zarr_version == array2._version
+    assert spec.zarr_format == array2._version
     assert spec.dtype == array2.dtype
     assert spec.attributes == array2.attrs
     assert spec.chunks == array2.chunks


### PR DESCRIPTION
this changes the erroneous `zarr_version` field of v2 array / group metadata to `zarr_format`, consistent with the v2 spec.

there are linting failures, but these are not due the changes here.

closes https://github.com/zarr-developers/pydantic-zarr/issues/48