### PR TITLE
pin python to 3.11 in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.11
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
should fix this [docs build failure,](https://github.com/zarr-developers/pydantic-zarr/actions/runs/16140595902/job/45546974880) which seemed to be triggered by an incompatibility between pydantic-core and python 3.13