### PR TITLE
implement arrayspec.to_zarr for v3

### DIFF
--- a/docs/usage_zarr_v3.md
+++ b/docs/usage_zarr_v3.md
@@ -72,7 +72,7 @@ print(spec.model_dump_json(indent=2))
       "fill_value": 0,
       "codecs": [
         {
-          "name": "GZip",
+          "name": "gzip",
           "configuration": {
             "level": 1
           }

--- a/docs/usage_zarr_v3.md
+++ b/docs/usage_zarr_v3.md
@@ -23,7 +23,7 @@ array_spec = ArraySpec(
     data_type="uint8",
     chunk_grid=NamedConfig(name="regular", configuration={"chunk_shape": [1000, 100]}),
     chunk_key_encoding=NamedConfig(name="default", configuration={"separator": "/"}),
-    codecs=[NamedConfig(name="GZip", configuration={"level": 1})],
+    codecs=[NamedConfig(name="gzip", configuration={"level": 1})],
     storage_transformers=(),
     fill_value=0,
 )
@@ -53,7 +53,7 @@ print(spec.model_dump_json(indent=2))
         1000,
         1000
       ],
-      "data_type": "|u1",
+      "data_type": "uint8",
       "chunk_grid": {
         "name": "regular",
         "configuration": {

--- a/src/pydantic_zarr/core.py
+++ b/src/pydantic_zarr/core.py
@@ -16,6 +16,18 @@ IncEx: TypeAlias = set[int] | set[str] | dict[int, Any] | dict[str, Any] | None
 AccessMode: TypeAlias = Literal["w", "w+", "r", "a"]
 
 
+def tuplify_json(obj: object) -> object:
+    """
+    Recursively converts lists within a Python object to tuples.
+    """
+    if isinstance(obj, list):
+        return tuple(tuplify_json(elem) for elem in obj)
+    elif isinstance(obj, dict):
+        return {k: tuplify_json(v) for k, v in obj.items()}
+    else:
+        return obj
+
+
 class StrictBase(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -366,11 +366,8 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         from zarr.storage._common import ensure_no_existing_node, make_store_path
 
         store_path = sync(make_store_path(store, path=path))
-        if overwrite:
-            if store_path.store.supports_deletes:
-                sync(store_path.delete_dir())
-            else:
-                sync(ensure_no_existing_node(store_path, zarr_format=3))
+        if overwrite and store_path.store.supports_deletes:
+            sync(store_path.delete_dir())
         else:
             sync(ensure_no_existing_node(store_path, zarr_format=3))
 

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Mapping
-from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -398,8 +397,8 @@ class GroupSpec(NodeSpec, Generic[TAttr, TItem]):
     """
 
     node_type: Literal["group"] = "group"
-    attributes: TAttr = MappingProxyType({})  # type: ignore[assignment]
-    members: Mapping[str, TItem] = MappingProxyType({})
+    attributes: TAttr = cast("TAttr", {})  # type: ignore[assignment]
+    members: Mapping[str, TItem] = cast("Mapping[str, TItem]", {})
 
     @classmethod
     def from_zarr(cls, group: zarr.Group) -> GroupSpec[TAttr, TItem]:

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -166,8 +166,8 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
     chunk_key_encoding: NamedConfig  # todo: validate this against shape
     fill_value: FillValue  # todo: validate this against the data type
     codecs: tuple[NamedConfig, ...]
-    storage_transformers: tuple[NamedConfig, ...]
-    dimension_names: tuple[str | None, ...] | None  # todo: validate this against shape
+    storage_transformers: tuple[NamedConfig, ...] = ()
+    dimension_names: tuple[str | None, ...] | None = None  # todo: validate this against shape
 
     def model_dump(
         self,

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -9,9 +9,7 @@ from typing import (
     Generic,
     Literal,
     Never,
-    NotRequired,
     Self,
-    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -22,7 +20,6 @@ import numpy as np
 import numpy.typing as npt
 import zarr
 from pydantic import BaseModel, BeforeValidator, Field
-from typing_extensions import ReadOnly
 
 from pydantic_zarr.core import IncEx, StrictBase, tuplify_json
 
@@ -32,6 +29,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
     import zarr
     from zarr.abc.store import Store
+    from zarr.core.array_spec import ArrayConfigParams
 
 
 TBaseAttr = Mapping[str, object]
@@ -50,11 +48,6 @@ ComplexFillValue = tuple[FloatFillValue, FloatFillValue]
 RawFillValue = tuple[int, ...]
 
 FillValue = BoolFillValue | IntFillValue | FloatFillValue | ComplexFillValue | RawFillValue
-
-
-class ArrayConfig(TypedDict):
-    order: NotRequired[ReadOnly[Literal["C", "F"]]]
-    write_empty_chunks: NotRequired[ReadOnly[bool]]
 
 
 class NamedConfig(StrictBase):
@@ -338,7 +331,12 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         )
 
     def to_zarr(
-        self, store: Store, path: str, *, overwrite: bool = False, config: ArrayConfig | None = None
+        self,
+        store: Store,
+        path: str,
+        *,
+        overwrite: bool = False,
+        config: ArrayConfigParams | None = None,
     ) -> zarr.Array:
         """
         Serialize an ArraySpec to a zarr array at a specific path in a zarr store.

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -233,8 +233,6 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
         if not isinstance(array.metadata, ArrayV3Metadata):
             raise ValueError("Only zarr v3 arrays are supported")  # noqa: TRY004
 
-        print(array.compressors)
-
         return cls(
             attributes=array.attrs.asdict(),
             shape=array.shape,

--- a/tests/test_pydantic_zarr/test_core.py
+++ b/tests/test_pydantic_zarr/test_core.py
@@ -1,9 +1,29 @@
+from __future__ import annotations
+
 import pytest
 
-from pydantic_zarr.core import ensure_member_name
+from pydantic_zarr.core import ensure_member_name, tuplify_json
 
 
 @pytest.mark.parametrize("data", ["/", "///", "a/b/", "a/b/vc"])
 def test_parse_str_no_path(data: str) -> None:
     with pytest.raises(ValueError, match='Strings containing "/" are invalid.'):
         ensure_member_name(data)
+
+
+@pytest.mark.parametrize(
+    ("input_obj", "expected_output"),
+    [
+        ({"key": [1, 2, 3]}, {"key": (1, 2, 3)}),
+        ([1, [2, 3], 4], (1, (2, 3), 4)),
+        ({"nested": {"list": [1, 2]}}, {"nested": {"list": (1, 2)}}),
+        ([{"a": [1, 2]}, {"b": 3}], ({"a": (1, 2)}, {"b": 3})),
+        ([], ()),
+    ],
+)
+def test_tuplify_json(input_obj: object, expected_output: object) -> None:
+    """
+    Test that tuplify_json converts lists to tuples, with recursion inside sequences
+    and dictionaries.
+    """
+    assert tuplify_json(input_obj) == expected_output


### PR DESCRIPTION
- removed a print statement
- some typing cleanup
- fixed dtype serialization errors for v3 arrays (we were recycling some zarr v2 stuff that doesn't work in v3)
- implemented `to_zarr` for v3 arrays.

it's super unfortunate that we have to use so much zarr python private API here. this 100% needs to be investigated on the zarr python side, because this process (creating a metadata document directly, and creating the array from it) feels very janky.