### PR TITLE
Allow zarr Arrays in from_array()

### DIFF
--- a/src/pydantic_zarr/v2.py
+++ b/src/pydantic_zarr/v2.py
@@ -184,7 +184,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
     @classmethod
     def from_array(
         cls,
-        array: npt.NDArray[Any],
+        array: npt.NDArray[Any] | zarr.Array,
         chunks: Literal["auto"] | tuple[int, ...] = "auto",
         attributes: Literal["auto"] | TAttr = "auto",
         fill_value: Literal["auto"] | float | None = "auto",

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -247,7 +247,7 @@ class ArraySpec(NodeSpec, Generic[TAttr]):
     @classmethod
     def from_array(
         cls,
-        array: npt.NDArray[Any],
+        array: npt.NDArray[Any] | zarr.Array,
         *,
         attributes: Literal["auto"] | TAttr = "auto",
         chunk_grid: Literal["auto"] | AnyNamedConfig = "auto",


### PR DESCRIPTION
Given the definitions of `auto_...`, it seems Zarr arrays are also intended to be allowed as input here.