### PR TITLE
Fix readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
     python: "3.12"
 
 mkdocs:
-  configuration: mkdocs.yml
+  configuration: mkdocs.yaml
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/pydantic-zarr/issues/69. I had to push an initial config file to `main` to bootstrap readthedocs, but now it's there I should be able to fix it in a PR.