### PR TITLE
disallow empty codecs, and use a sane default in auto_codecs, allow codecs to be specified by strings

### DIFF
--- a/src/pydantic_zarr/core.py
+++ b/src/pydantic_zarr/core.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Literal,
     TypeAlias,
+    TypeVar,
     overload,
 )
 
@@ -23,6 +24,8 @@ if TYPE_CHECKING:
 IncEx: TypeAlias = set[int] | set[str] | dict[int, Any] | dict[str, Any] | None
 
 AccessMode: TypeAlias = Literal["w", "w+", "r", "a"]
+
+T = TypeVar("T")
 
 
 @overload
@@ -133,3 +136,12 @@ def maybe_node(
         return get_node(spath.store, spath.path, zarr_format=zarr_format)
     except FileNotFoundError:
         return None
+
+
+def ensure_multiple(data: Sequence[T]) -> Sequence[T]:
+    """
+    Ensure that there is at least one element in the sequence
+    """
+    if len(data) < 1:
+        raise ValueError("Invalid length. Expected 1 or more, got 0.")
+    return data

--- a/src/pydantic_zarr/v3.py
+++ b/src/pydantic_zarr/v3.py
@@ -30,6 +30,7 @@ from pydantic_zarr.core import (
     IncEx,
     StrictBase,
     ensure_key_no_path,
+    ensure_multiple,
     maybe_node,
     model_like,
     tuplify_json,
@@ -164,16 +165,8 @@ def parse_dtype_v3(dtype: npt.DTypeLike | Mapping[str, object]) -> Mapping[str, 
                 raise ValueError(f"Unsupported dtype: {dtype}")
 
 
-T = TypeVar("T")
-
-
-def ensure_multiple(data: Sequence[T]) -> Sequence[T]:
-    if len(data) < 1:
-        raise ValueError("Invalid length. Expected 1 or more, got 0.")
-    return data
-
-
-DTypeLike = Annotated[str, BeforeValidator(parse_dtype_v3)] | AnyNamedConfig
+DTypeStr = Annotated[str, BeforeValidator(parse_dtype_v3)]
+DTypeLike = DTypeStr | AnyNamedConfig
 CodecTuple = Annotated[tuple[CodecLike, ...], BeforeValidator(ensure_multiple)]
 
 

--- a/tests/test_pydantic_zarr/test_v3.py
+++ b/tests/test_pydantic_zarr/test_v3.py
@@ -48,6 +48,7 @@ def test_serialize_deserialize() -> None:
 def test_from_array() -> None:
     array = np.arange(10)
     array_spec = ArraySpec.from_array(array)
+
     assert array_spec == ArraySpec(
         zarr_format=3,
         node_type="array",
@@ -65,6 +66,9 @@ def test_from_array() -> None:
         storage_transformers=(),
         dimension_names=None,
     )
+    # check that we can write this array to zarr
+    # TODO: fix type of the store argument in to_zarr
+    array_spec.to_zarr(store={}, path="")  # type: ignore[arg-type]
 
 
 def test_arrayspec_no_empty_codecs() -> None:


### PR DESCRIPTION
closes #93 by ensuring that we require `codecs` to be non-empty, and also adding `{"name": "bytes"}` to the default output of `auto_codecs`

I also made the type annotations for codecs more consistent with the zarr v3 spec, since codecs can be declared as plain strings as of the recent zep changes.

closes #93 